### PR TITLE
Accept payplug-magento2 4.6.x not just 4.6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "hyva-themes/magento2-compat-module-fallback": "*",
         "hyva-themes/magento2-hyva-checkout": "1.3.5",
         "magento/framework": "*",
-        "payplug/payplug-magento2": "4.6.0"
+        "payplug/payplug-magento2": "^4.6"
     },
     "autoload": {
         "files": [


### PR DESCRIPTION
Hi,
We need a fix in payplug/payplug-magento2 but your module is too specific in the require (4.6.0), we need 4.6.1
Thanks.